### PR TITLE
Update to latest build of Rust. A  tag for associated_types have been ad...

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -2,7 +2,7 @@ use std::iter;
 use std::str;
 
 /// A parsing error, with location information.
-#[deriving(Show, PartialEq)]
+#[derive(Show, PartialEq)]
 pub struct ParseError {
   /// The line of input the error is on.
   pub line_number:   uint,
@@ -140,7 +140,9 @@ impl<'a> Lexer<'a> {
   }
 }
 
-impl<'a> Iterator<String> for Lexer<'a> {
+impl<'a> Iterator for Lexer<'a> {
+  type Item = String;
+
   fn next(&mut self) -> Option<String> {
     self.next_word().map(|buf| {
       match String::from_utf8(buf) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![crate_type = "lib"]
 #![deny(warnings)]
 #![deny(missing_docs)]
+#![feature(associated_types)]
 
 pub use lex::ParseError;
 

--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -1,5 +1,7 @@
 //! A parser for Wavefront's `.mtl` file format, for storing information about
 //! the material of which a 3D mesh is composed.
+use std::cmp::Ordering;
+use std::cmp::Ordering::{Equal, Less, Greater};
 use std::iter;
 use std::num::Float;
 use std::borrow::ToOwned;
@@ -8,7 +10,7 @@ pub use lex::ParseError;
 use lex::Lexer;
 
 /// A set of materials in one `.mtl` file.
-#[deriving(Clone, Show, PartialEq)]
+#[derive(Clone, Show, PartialEq)]
 #[allow(missing_docs)]
 pub struct MtlSet {
   pub materials: Vec<Material>,
@@ -16,7 +18,7 @@ pub struct MtlSet {
 
 /// A single material that can be applied to any face. They are generally
 /// applied by using the Phong shading model.
-#[deriving(Clone, Show)]
+#[derive(Clone, Show)]
 #[allow(missing_docs)]
 pub struct Material {
   pub name: String,
@@ -31,7 +33,7 @@ pub struct Material {
 }
 
 /// How a given material is supposed to be illuminated.
-#[deriving(Clone, Copy, Show, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Show, Eq, PartialEq, Ord, PartialOrd)]
 #[allow(missing_docs)]
 pub enum Illumination {
   Ambient,
@@ -39,7 +41,7 @@ pub enum Illumination {
   AmbientDiffuseSpecular,
 }
 
-#[deriving(Clone, Copy, Show)]
+#[derive(Clone, Copy, Show)]
 #[allow(missing_docs)]
 pub struct Color {
   pub r: f64,

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -1,4 +1,6 @@
 //! A parser for Wavefront's `.obj` file format for storing 3D meshes.
+use std::cmp::Ordering;
+use std::cmp::Ordering::{Equal, Less, Greater};
 use std::iter;
 use std::mem;
 use std::num::Float;
@@ -7,7 +9,7 @@ use std::borrow::ToOwned;
 use lex::{ParseError,Lexer};
 
 /// A set of objects, as listed in an `.obj` file.
-#[deriving(Clone, Show, PartialEq)]
+#[derive(Clone, Show, PartialEq)]
 pub struct ObjSet {
   /// Which material library to use.
   pub material_library: String,
@@ -16,7 +18,7 @@ pub struct ObjSet {
 }
 
 /// A mesh object.
-#[deriving(Clone, Show, PartialEq)]
+#[derive(Clone, Show, PartialEq)]
 pub struct Object {
   /// A human-readable name for this object. This can be set in blender.
   pub name: String,
@@ -35,7 +37,7 @@ pub struct Object {
 }
 
 /// A set of shapes, all using the given material.
-#[deriving(Clone, Show, PartialEq)]
+#[derive(Clone, Show, PartialEq)]
 pub struct Geometry {
   /// A reference to the material to apply to this geometry.
   pub material_name: Option<String>,
@@ -49,7 +51,7 @@ pub struct Geometry {
 ///
 /// Convex polygons more complicated than a triangle are automatically
 /// converted into triangles.
-#[deriving(Clone, Copy, Show, Hash, PartialEq)]
+#[derive(Clone, Copy, Show, Hash, PartialEq)]
 pub enum Shape {
   /// A point specified by its position.
   Point(VTIndex),
@@ -61,7 +63,7 @@ pub enum Shape {
 
 /// A single 3-dimensional point on the corner of an object.
 #[allow(missing_docs)]
-#[deriving(Clone, Copy, Show)]
+#[derive(Clone, Copy, Show)]
 pub struct Vertex {
   pub x: f64,
   pub y: f64,
@@ -73,7 +75,7 @@ pub type Normal = Vertex;
 
 /// A single 2-dimensional point on a texture. "Texure Vertex".
 #[allow(missing_docs)]
-#[deriving(Clone, Copy, Show)]
+#[derive(Clone, Copy, Show)]
 pub struct TVertex {
   pub x: f64,
   pub y: f64,


### PR DESCRIPTION
* A feature tag for `associated_types` has been added to the crate library in order to support the associated types required by the Iterator Trait.
* `deriving` has been changed to `derive` 
* Explicit use of the `Ordering` enum and the comparators in `mtl.rs` and `obj.rs`