### PR TITLE
Update for latest build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@
 name = "wavefront_obj"
 description = "A parser for the Wavefront .obj file format."
 license = "MIT"
-license-file = "LICENSE"
 repository = "https://github.com/PistonDevelopers/wavefront_obj"
 version = "0.0.1"
 authors = [

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -5,7 +5,7 @@ use std::str;
 #[derive(Show, PartialEq)]
 pub struct ParseError {
   /// The line of input the error is on.
-  pub line_number:   uint,
+  pub line_number:   usize,
   /// The error message.
   pub message:       String,
 }
@@ -17,7 +17,7 @@ fn is_whitespace(c: u8) -> bool {
 
 pub struct Lexer<'a> {
   bytes: iter::Peekable<u8, str::Bytes<'a>>,
-  current_line_number: uint,
+  current_line_number: usize,
 }
 
 impl<'a> Lexer<'a> {
@@ -52,7 +52,7 @@ impl<'a> Lexer<'a> {
   ///
   /// Postcondition: Either the end of the input was reached or
   /// `is_true` returns false for the currently peekable character.
-  fn skip_while(&mut self, is_true: |u8| -> bool) -> bool {
+  fn skip_while<F: Fn(u8) -> bool>(&mut self, is_true: F) -> bool {
     let mut was_anything_skipped = false;
 
     loop {
@@ -77,7 +77,7 @@ impl<'a> Lexer<'a> {
   ///
   /// Postcondition: Either the end of the input was reached or
   /// `is_false` returns true for the currently peekable character.
-  fn skip_unless(&mut self, is_false: |u8| -> bool) -> bool {
+  fn skip_unless<F: Fn(u8) -> bool>(&mut self, is_false: F) -> bool {
     self.skip_while(|c| !is_false(c))
   }
 
@@ -152,7 +152,7 @@ impl<'a> Iterator for Lexer<'a> {
     })
   }
 
-  fn size_hint(&self) -> (uint, Option<uint>) {
+  fn size_hint(&self) -> (usize, Option<usize>) {
     (0, None)
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 #![allow(unstable)]
-#![feature(unboxed_closures)]
 
 pub use lex::ParseError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 #![crate_type = "lib"]
 #![deny(warnings)]
 #![deny(missing_docs)]
-#![feature(associated_types)]
+#![allow(unstable)]
+#![feature(unboxed_closures)]
 
 pub use lex::ParseError;
 

--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -112,7 +112,7 @@ fn sliced<'a>(s: &'a Option<String>) -> Option<&'a str> {
 }
 
 struct Parser<'a> {
-  line_number: uint,
+  line_number: usize,
   lexer: iter::Peekable<String, Lexer<'a>>,
 }
 
@@ -210,14 +210,14 @@ impl<'a> Parser<'a> {
     }
   }
 
-  fn parse_uint(&mut self) -> Result<uint, ParseError> {
+  fn parse_usize(&mut self) -> Result<usize, ParseError> {
     match sliced(&self.next()) {
       None =>
-        return self.error("Expected uint but got end of input.".to_owned()),
+        return self.error("Expected usize but got end of input.".to_owned()),
       Some(s) => {
         match s.parse() {
           None =>
-            return self.error(format!("Expected uint but got {}.", s)),
+            return self.error(format!("Expected usize but got {}.", s)),
           Some(ret) =>
             Ok(ret)
         }
@@ -284,7 +284,7 @@ impl<'a> Parser<'a> {
 
   fn parse_illumination(&mut self) -> Result<Illumination, ParseError> {
     try!(self.parse_tag("illum"));
-    match try!(self.parse_uint()) {
+    match try!(self.parse_usize()) {
       0 => Ok(Illumination::Ambient),
       1 => Ok(Illumination::AmbientDiffuse),
       2 => Ok(Illumination::AmbientDiffuseSpecular),


### PR DESCRIPTION
* Removed `license-file` field from Cargo.toml, alternatively the `license` field can be removed instead, but both are not necessary.
* Allow `unstable` tag has been added to the library, in order to shadow the warnings about use of unstable items. Alternatively, we can allow `warnings` instead.  
* Replaced all occurrences of `int` and `uint` with `isize` and `usize`. Note that the functions that parses the values has also been changed to `parse_usize` and `parse_isize_from`, respectively.