### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "wavefront_obj"
-version = "2.0.4"
+version = "3.0.0"
 authors = [
     "Clark Gaebel <cg.wowus.cg@gmail.com>",
 ]


### PR DESCRIPTION
cc @cgaebel 

Because https://github.com/PistonDevelopers/wavefront_obj/pull/45 is a breaking change, I think we should follow strict semver and bump it to 3.0.0.