### PR TITLE
Optimize parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ license     = "MIT"
 readme      = "README.md"
 repository  = "https://github.com/PistonDevelopers/wavefront_obj.git"
 homepage    = "https://github.com/PistonDevelopers/wavefront_obj"
+
+[dependencies]
+lexical = "2.1.0"

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -37,11 +37,8 @@ impl<'a> Lexer<'a> {
 
   /// Advance the lexer by one character.
   fn advance(&mut self) {
-    match self.peek() {
-      Some(&c) if c == b'\n' => {
-        self.current_line_number += 1;
-      }
-      _ => {}
+    if let Some(b'\n') = self.peek() {
+      self.current_line_number += 1;
     }
     self.read_pos += 1;
   }
@@ -115,11 +112,11 @@ impl<'a> Lexer<'a> {
     match self.peek() {
       Some(b'\n') => {
         self.advance();
-        Some(&self.bytes[start_ptr..self.read_pos]) // newline
+        self.bytes.get(start_ptr..self.read_pos) // newline
       }
       Some(_) => {
         if self.skip_unless(|c| is_whitespace(c) || c == b'#') {
-          Some(&self.bytes[start_ptr..self.read_pos])
+          self.bytes.get(start_ptr..self.read_pos)
         } else {
           None
         }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -1,13 +1,12 @@
-use std::iter;
 use std::str;
 
 /// A parsing error, with location information.
 #[derive(Debug, PartialEq)]
 pub struct ParseError {
   /// The line of input the error is on.
-  pub line_number:   usize,
+  pub line_number: usize,
   /// The error message.
-  pub message:       String,
+  pub message: String,
 }
 
 #[inline]
@@ -22,31 +21,34 @@ fn is_whitespace(c: u8) -> bool {
 
 #[derive(Clone)]
 pub struct Lexer<'a> {
-  bytes: iter::Peekable<str::Bytes<'a>>,
+  bytes: &'a [u8],
+  read_pos: usize,
   current_line_number: usize,
 }
 
 impl<'a> Lexer<'a> {
   pub fn new(input: &'a str) -> Lexer<'a> {
     Lexer {
-      bytes: input.bytes().peekable(),
+      bytes: input.as_bytes(),
+      read_pos: 0,
       current_line_number: 1,
     }
   }
 
   /// Advance the lexer by one character.
   fn advance(&mut self) {
-    match self.bytes.next() {
-      Some(c) if c == b'\n' => {
+    match self.peek() {
+      Some(&c) if c == b'\n' => {
         self.current_line_number += 1;
       }
-      _ => {},
+      _ => {}
     }
+    self.read_pos += 1;
   }
 
   /// Looks at the next character the lexer is pointing to.
-  fn peek(&mut self) -> Option<u8> {
-    self.bytes.peek().map(|&x| x)
+  fn peek(&self) -> Option<&u8> {
+    self.bytes.get(self.read_pos)
   }
 
   /// Advance past characters until the given condition is true.
@@ -61,7 +63,7 @@ impl<'a> Lexer<'a> {
     loop {
       match self.peek() {
         None => break,
-        Some(c) if !is_true(c) => break,
+        Some(&c) if !is_true(c) => break,
         _ => {
           self.advance();
           was_anything_skipped = true;
@@ -69,7 +71,7 @@ impl<'a> Lexer<'a> {
       }
     }
 
-    debug_assert!(self.peek().map(|c| !is_true(c)).unwrap_or(true));
+    debug_assert!(self.peek().map(|&c| !is_true(c)).unwrap_or(true));
 
     was_anything_skipped
   }
@@ -89,16 +91,12 @@ impl<'a> Lexer<'a> {
   /// Returns whether or not any of the input was skipped.
   fn skip_comment(&mut self) -> bool {
     match self.peek() {
-      None => false,
-      Some(c) => {
-        if c == b'#' {
-          // skip over the rest of the comment (except the newline)
-          self.skip_unless(|c| c == b'\n');
-          true
-        } else {
-          false
-        }
+      Some(b'#') => {
+        // skip over the rest of the comment (except the newline)
+        self.skip_unless(|c| c == b'\n');
+        true
       }
+      _ => false,
     }
   }
 
@@ -108,78 +106,88 @@ impl<'a> Lexer<'a> {
 
   /// Gets the next word in the input, as well as whether it's on
   /// a different line than the last word we got.
-  fn next_word(&mut self) -> Option<Vec<u8>> {
-    let mut ret: Vec<u8> = Vec::new();
-
+  fn next_word(&mut self) -> Option<&'a [u8]> {
     self.skip_whitespace_except_newline();
+    self.skip_comment();
 
-    loop {
-      match self.peek() {
-        None => break,
-        Some(c) => {
-          if c == b'#' {
-            assert!(self.skip_comment());
-            self.skip_whitespace_except_newline();
-          } else if is_whitespace(c) {
-            if c == b'\n' && ret.is_empty() {
-              ret.push(c);
-              self.advance();
-            }
-            break;
-          } else {
-            ret.push(c);
-            self.advance();
-          }
+    let start_ptr = self.read_pos;
+
+    match self.peek() {
+      Some(b'\n') => {
+        self.advance();
+        Some(&self.bytes[start_ptr..self.read_pos]) // newline
+      }
+      Some(_) => {
+        if self.skip_unless(|c| is_whitespace(c) || c == b'#') {
+          Some(&self.bytes[start_ptr..self.read_pos])
+        } else {
+          None
         }
       }
-    }
-
-    if ret.is_empty() {
-      debug_assert_eq!(self.peek(), None);
-      None
-    } else {
-      Some(ret)
+      None => None,
     }
   }
 }
 
-impl<'a> Iterator for Lexer<'a> {
-  type Item = String;
+#[derive(Clone)]
+pub struct PeekableLexer<'a> {
+  inner: Lexer<'a>,
+  peeked: Option<Option<&'a str>>,
+}
 
-  fn next(&mut self) -> Option<String> {
-    self.next_word().map(|buf| {
-      match String::from_utf8(buf) {
-        Ok(s) => s,
-        Err(_) => panic!("Lex error: Invalid utf8 on line {}.", self.current_line_number),
-      }
-    })
+impl<'a> PeekableLexer<'a> {
+  pub fn new(lexer: Lexer<'a>) -> Self {
+    Self {
+      inner: lexer,
+      peeked: None,
+    }
+  }
+  pub fn next_str(&mut self) -> Option<&'a str> {
+    match self.peeked.take() {
+      Some(v) => v,
+      None => self
+        .inner
+        .next_word()
+        .map(|buf| unsafe { str::from_utf8_unchecked(buf) }),
+    }
   }
 
-  fn size_hint(&self) -> (usize, Option<usize>) {
-    (0, None)
+  pub fn peek_str(&mut self) -> Option<&'a str> {
+    match self.peeked {
+      Some(v) => v,
+      None => {
+        let peek = self
+          .inner
+          .next_word()
+          .map(|buf| unsafe { str::from_utf8_unchecked(buf) });
+
+        self.peeked.replace(peek);
+        peek
+      }
+    }
   }
 }
 
 #[test]
 fn test_next_word() {
   let mut l = Lexer::new("hello wor\rld\n this# is\r\na   \t test\n");
-  assert_eq!(l.next_word(), Some(b"hello".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"hello"[..]));
   assert_eq!(l.current_line_number, 1);
-  assert_eq!(l.next_word(), Some(b"wor".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"wor"[..]));
   assert_eq!(l.current_line_number, 1);
-  assert_eq!(l.next_word(), Some(b"ld".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"ld"[..]));
   assert_eq!(l.current_line_number, 1);
-  assert_eq!(l.next_word(), Some(b"\n".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"\n"[..]));
   assert_eq!(l.current_line_number, 2);
-  assert_eq!(l.next_word(), Some(b"this".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"this"[..]));
   assert_eq!(l.current_line_number, 2);
-  assert_eq!(l.next_word(), Some(b"\n".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"\n"[..]));
   assert_eq!(l.current_line_number, 3);
-  assert_eq!(l.next_word(), Some(b"a".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"a"[..]));
   assert_eq!(l.current_line_number, 3);
-  assert_eq!(l.next_word(), Some(b"test".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"test"[..]));
   assert_eq!(l.current_line_number, 3);
-  assert_eq!(l.next_word(), Some(b"\n".to_vec()));
+  assert_eq!(l.next_word(), Some(&b"\n"[..]));
   assert_eq!(l.current_line_number, 4);
   assert_eq!(l.next_word(), None);
 }

--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -169,7 +169,6 @@ impl<'a> Parser<'a> {
   }
 
   fn peek(&mut self) -> Option<&'a str> {
-    // TODO(cgaebel): See the comment in `next`.
     self.lexer.peek_str()
   }
 
@@ -187,7 +186,7 @@ impl<'a> Parser<'a> {
   /// Skips over some newlines, failing if it didn't manage to skip any.
   fn one_or_more_newlines(&mut self) -> Result<(), ParseError> {
     match self.peek() {
-      None => return self.error("Expected newline but got end of input.".to_owned()),
+      None => {} // allow eof
       Some("\n") => {}
       Some(s) => return self.error(format!("Expected newline but got {}", s)),
     }
@@ -388,9 +387,8 @@ impl<'a> Parser<'a> {
 /// best-effort and realistically I will only end up supporting the subset
 /// of the file format which falls under the "shit I see exported from blender"
 /// category.
-pub fn parse(mut input: String) -> Result<MtlSet, ParseError> {
-  input.push_str("\n");
-  Parser::new(&input[..]).parse_mtlset()
+pub fn parse<S: AsRef<str>>(input: S) -> Result<MtlSet, ParseError> {
+  Parser::new(input.as_ref()).parse_mtlset()
 }
 
 #[test]
@@ -429,9 +427,7 @@ Kd 0.8 0.8 0.8
 # specular
 Ks 0.8 0.8 0.8
 d 1
-illum 2
-
-"#;
+illum 2"#;
 
   let expected = Ok(MtlSet {
     materials: vec![
@@ -490,7 +486,7 @@ illum 2
     ],
   });
 
-  assert_eq!(parse(test_case.to_owned()), expected);
+  assert_eq!(parse(test_case), expected);
 }
 
 #[test]
@@ -544,5 +540,5 @@ map_Kd cube-uv-num.png
     }],
   });
 
-  assert_eq!(parse(test_case.to_owned()), expected);
+  assert_eq!(parse(test_case), expected);
 }


### PR DESCRIPTION
This PR introduces 3 main changes: 
- the whole parsing is using only slices to initial parser input, tokens are not allocated independently
- numeric parsing is performed using "lexical" crate for superior performance
- parsing accepts `&str` instead of `mut String` as input, due to changes in parser so it no longer requires trailing newline. This also gets rid of unnecessary input string reallocation.
- there is unfortunately some noise due to rustfmt pass that was automatically done by my editor and I didn't noticed until it's already done. I hope it's not a big problem.

Many of solved problems were previously noticed in the source code in various TODO comments which are now removed.

All changes should be mostly backward-compatible, the only breaking change is due to the fact that the input type is generic `S: AsRef<str>`, which commonly breaks `.into()` usage on `&str`. It's not a big deal, because this cast is no longer necessary at all and getting rid of `.into()` will do the job.

In our tests, when loading a ~50MB obj file, we were able to achieve around 5x speedup on release build (from ~7s to ~1.4s).