### PR TITLE
Fix obj::parse looping infinitely.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ homepage    = "https://github.com/PistonDevelopers/wavefront_obj"
 
 [dependencies]
 lexical = "2.1.0"
+
+[dev-dependencies]
+proptest = "0.9"

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -48,6 +48,18 @@ impl<'a> Lexer<'a> {
     self.bytes.get(self.read_pos)
   }
 
+  /// Return the number of bytes read since the last lexer state provided as argument.
+  ///
+  /// Return [`None`] if the checkpoint parser is more advanced in the input than the current one —
+  /// i.e. you have likely swapped the parsers, try calling the other way around!
+  pub fn bytes_consumed(&self, checkpoint: &Self) -> Option<usize> {
+    if self.read_pos < checkpoint.read_pos {
+      None
+    } else {
+      Some(self.read_pos - checkpoint.read_pos)
+    }
+  }
+
   /// Advance past characters until the given condition is true.
   ///
   /// Returns whether or not any of the input was skipped.
@@ -162,6 +174,14 @@ impl<'a> PeekableLexer<'a> {
         peek
       }
     }
+  }
+
+  /// Return the number of bytes read since the last lexer state provided as argument.
+  ///
+  /// Return [`None`] if the checkpoint parser is more advanced in the input than the current one —
+  /// i.e. you have likely swapped the parsers, try calling the other way around!
+  pub fn bytes_consumed(&self, checkpoint: &Self) -> Option<usize> {
+    self.inner.bytes_consumed(&checkpoint.inner)
   }
 }
 

--- a/tests/corrupted_data.rs
+++ b/tests/corrupted_data.rs
@@ -1,0 +1,13 @@
+extern crate proptest;
+extern crate wavefront_obj;
+
+use proptest::prelude::*;
+use wavefront_obj::obj;
+
+proptest! {
+  #[test]
+  fn detect_corrupted_data(s in "[:alphanum:]+") {
+    let result = obj::parse(s);
+    assert!(result.is_err());
+  }
+}


### PR DESCRIPTION
The fix was made possible by introducing the concept of parser
difference, which is simply computing how much of input data was
consumed between two parser states. Cloning a parser is a very
lightweiht operation as parsers are just borrowed input decorated with
some bytes tracking (usize). We can then easily observe if a successful
parser is successful because it just peeked without consuming anything,
which is a good sign of corrupted data.

In a better world, we should have more strict parsing, especially in
parse_geometries, which as a wildcard pattern-matching (that should be
removed and replaced with a strict alternative, IMHO).

Fixes #62