### PR TITLE
Add illumination entry for illum=3

### DIFF
--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -46,6 +46,7 @@ pub enum Illumination {
   Ambient,
   AmbientDiffuse,
   AmbientDiffuseSpecular,
+  ReflectionRayTrace,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -299,6 +300,7 @@ impl<'a> Parser<'a> {
       0 => Ok(Illumination::Ambient),
       1 => Ok(Illumination::AmbientDiffuse),
       2 => Ok(Illumination::AmbientDiffuseSpecular),
+      3 => Ok(Illumination::ReflectionRayTrace),
       n => self.error(format!("Unknown illumination model: {}.", n)),
     }
   }


### PR DESCRIPTION
It seems like there are many values of `illum` which are described in the spec: http://paulbourke.net/dataformats/mtl/.

Since this library attempts to support Blender-exported MTL files, I thought it was worth adding illum=3. This value is written by Blender when exporting a material which uses the Principled BSDF with Metallic = 1. The description in the spec is "Reflection on and Ray trace on", so I chose a name which is similar in character to the existing names.

Also of note, the spec describes illum=0 as "Color on and Ambient off", which would suggest that `Illumination::Ambient` is misnamed, and should be `Illumination::Diffuse`.