### PR TITLE
Update `lexical` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository  = "https://github.com/PistonDevelopers/wavefront_obj.git"
 homepage    = "https://github.com/PistonDevelopers/wavefront_obj"
 
 [dependencies]
-lexical = "2.1.0"
+lexical = "5.2"
 
 [dev-dependencies]
 proptest = "0.9"

--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -219,7 +219,7 @@ impl<'a> Parser<'a> {
     match self.next() {
       None => self.error("Expected f64 but got end of input.".to_owned()),
       Some(s) => {
-        lexical::try_parse(&s).map_err(|_| self.error_raw(format!("Expected f64 but got {}.", s)))
+        lexical::parse(&s).map_err(|_| self.error_raw(format!("Expected f64 but got {}.", s)))
       }
     }
   }
@@ -228,7 +228,7 @@ impl<'a> Parser<'a> {
     match self.next() {
       None => self.error("Expected usize but got end of input.".to_owned()),
       Some(s) => {
-        lexical::try_parse(&s).map_err(|_| self.error_raw(format!("Expected usize but got {}.", s)))
+        lexical::parse(&s).map_err(|_| self.error_raw(format!("Expected usize but got {}.", s)))
       }
     }
   }

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -370,7 +370,7 @@ impl<'a> Parser<'a> {
   // I can't think of a good reason to do this except to make testing easier.
   fn parse_double(&mut self) -> Result<f64, ParseError> {
     let s = self.parse_str()?;
-    lexical::try_parse(s).map_err(|_| self.error_raw(format!("Expected f64 but got {}.", s)))
+    lexical::parse(s).map_err(|_| self.error_raw(format!("Expected f64 but got {}.", s)))
   }
 
   fn parse_vertex(&mut self) -> Result<Vertex, ParseError> {
@@ -413,12 +413,12 @@ impl<'a> Parser<'a> {
 
   #[inline]
   fn parse_isize_from(&self, s: &str) -> Result<isize, ParseError> {
-    lexical::try_parse(&s).map_err(|_| self.error_raw(format!("Expected isize but got {}.", s)))
+    lexical::parse(&s).map_err(|_| self.error_raw(format!("Expected isize but got {}.", s)))
   }
 
   fn parse_u32(&mut self) -> Result<u32, ParseError> {
     let s = self.parse_str()?;
-    lexical::try_parse(&s).map_err(|_| self.error_raw(format!("Expected u32 but got {}.", s)))
+    lexical::parse(&s).map_err(|_| self.error_raw(format!("Expected u32 but got {}.", s)))
   }
 
   fn parse_vtindex(


### PR DESCRIPTION
Updates the `lexical` dependency to the latest version.

This fixed a compile error on the latest rust nightly for me