### PR TITLE
remove dependency on lexical

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,5 @@ readme      = "README.md"
 repository  = "https://github.com/PistonDevelopers/wavefront_obj.git"
 homepage    = "https://github.com/PistonDevelopers/wavefront_obj"
 
-[dependencies]
-lexical = "5.2"
-
 [dev-dependencies]
 proptest = "0.9"

--- a/src/mtl.rs
+++ b/src/mtl.rs
@@ -139,7 +139,7 @@ impl PartialOrd for Material {
         .lexico(|| self.dissolve_map.cmp(&other.dissolve_map))
         .lexico(|| self.displacement_map.cmp(&other.displacement_map))
         .lexico(|| self.decal_map.cmp(&other.decal_map))
-        .lexico(|| self.bump_map.cmp(&other.bump_map))
+        .lexico(|| self.bump_map.cmp(&other.bump_map)),
     )
   }
 }
@@ -219,18 +219,18 @@ impl<'a> Parser<'a> {
   fn parse_f64(&mut self) -> Result<f64, ParseError> {
     match self.next() {
       None => self.error("Expected f64 but got end of input.".to_owned()),
-      Some(s) => {
-        lexical::parse(&s).map_err(|_| self.error_raw(format!("Expected f64 but got {}.", s)))
-      }
+      Some(s) => s
+        .parse()
+        .map_err(|_| self.error_raw(format!("Expected f64 but got {}.", s))),
     }
   }
 
   fn parse_usize(&mut self) -> Result<usize, ParseError> {
     match self.next() {
       None => self.error("Expected usize but got end of input.".to_owned()),
-      Some(s) => {
-        lexical::parse(&s).map_err(|_| self.error_raw(format!("Expected usize but got {}.", s)))
-      }
+      Some(s) => s
+        .parse()
+        .map_err(|_| self.error_raw(format!("Expected usize but got {}.", s))),
     }
   }
 
@@ -307,7 +307,11 @@ impl<'a> Parser<'a> {
 
   fn parse_map(&mut self, name: &'static str) -> Result<Option<&'a str>, ParseError> {
     match self.peek() {
-      Some(s) => if s != name { return Ok(None) },
+      Some(s) => {
+        if s != name {
+          return Ok(None);
+        }
+      }
       _ => return Ok(None),
     }
 

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -370,7 +370,8 @@ impl<'a> Parser<'a> {
   // I can't think of a good reason to do this except to make testing easier.
   fn parse_double(&mut self) -> Result<f64, ParseError> {
     let s = self.parse_str()?;
-    lexical::parse(s).map_err(|_| self.error_raw(format!("Expected f64 but got {}.", s)))
+    s.parse()
+      .map_err(|_| self.error_raw(format!("Expected f64 but got {}.", s)))
   }
 
   fn parse_vertex(&mut self) -> Result<Vertex, ParseError> {
@@ -413,12 +414,14 @@ impl<'a> Parser<'a> {
 
   #[inline]
   fn parse_isize_from(&self, s: &str) -> Result<isize, ParseError> {
-    lexical::parse(&s).map_err(|_| self.error_raw(format!("Expected isize but got {}.", s)))
+    s.parse()
+      .map_err(|_| self.error_raw(format!("Expected isize but got {}.", s)))
   }
 
   fn parse_u32(&mut self) -> Result<u32, ParseError> {
     let s = self.parse_str()?;
-    lexical::parse(&s).map_err(|_| self.error_raw(format!("Expected u32 but got {}.", s)))
+    s.parse()
+      .map_err(|_| self.error_raw(format!("Expected u32 but got {}.", s)))
   }
 
   fn parse_vtindex(


### PR DESCRIPTION
As noted in the advisory, there's little reason to not use std float parsing.

Fixes #76